### PR TITLE
tracklist: Remove on_error_step from play() call

### DIFF
--- a/mopidy_touchscreen/screens/tracklist.py
+++ b/mopidy_touchscreen/screens/tracklist.py
@@ -36,8 +36,7 @@ class Tracklist(BaseScreen):
     def touch_event(self, touch_event):
         pos = self.list_view.touch_event(touch_event)
         if pos is not None:
-            self.manager.core.playback.play(self.tracks[pos],
-                                                    on_error_step=1)
+            self.manager.core.playback.play(self.tracks[pos])
 
     def track_started(self, track):
         self.list_view.set_active(


### PR DESCRIPTION
The `on_error_step` argument was made internal in Mopidy 1.0.
