### PR TITLE
fixed playlist tracks without names

### DIFF
--- a/mopidy_touchscreen/screens/playlist_screen.py
+++ b/mopidy_touchscreen/screens/playlist_screen.py
@@ -38,7 +38,11 @@ class PlaylistScreen(BaseScreen):
         self.playlist_tracks = playlist.tracks
         self.playlist_tracks_strings = ["../"]
         for track in self.playlist_tracks:
-            self.playlist_tracks_strings.append(track.name)
+            if track.name is None:
+                self.playlist_tracks_strings.append(track.uri)
+            else:
+                self.playlist_tracks_strings.append(track.name)
+
         self.list_view.set_list(self.playlist_tracks_strings)
 
     def touch_event(self, touch_event):


### PR DESCRIPTION
Hi,
currently the playlist screen hangs when an m3u file has only a url to a stream and the stream doesn't supply a stream name.
This commit fixes this problem.
